### PR TITLE
adding secondary and auxiliary fields for apple wallet pass

### DIFF
--- a/backend/src/__tests__/applewallet.service.test.ts
+++ b/backend/src/__tests__/applewallet.service.test.ts
@@ -2,7 +2,7 @@ import { createPass } from '../services/applewallet.service';
 
 describe('createPass ', () => {
   test('generates a pkpass buffer', async () => {
-    const result = await createPass({ serial: '123', number: 'ABC' });
+    const result = await createPass({ serial: '123', number: 'ABC', bin: '015926', pcn: 'PRXIDST', group: 'IDST01', memberId: 'IDST733224411' });
     expect(result).toBeDefined();
     expect(result.length).toBeGreaterThan(0);
   });

--- a/backend/src/routes/applewallet.route.ts
+++ b/backend/src/routes/applewallet.route.ts
@@ -12,10 +12,10 @@ router.get('/', async (req, res, next) => {
     const pkpass = await createPass({
       serial: '90MA019309343023',
       number: '90MA019309343023',
-      bin: '015926',
-      pcn: 'PRXIDST',
-      group: 'IDST01',
-      memberId: 'IDST733224411',
+      bin: '020750',
+      pcn: 'NMeds',
+      group: 'NEEDYMED',
+      memberId: '90MA019309343023',
     });
 
     res.setHeader('Content-Type', 'application/vnd.apple.pkpass');

--- a/backend/src/routes/applewallet.route.ts
+++ b/backend/src/routes/applewallet.route.ts
@@ -8,11 +8,10 @@ router.get('/', async (req, res, next) => {
   console.log('Route hit');
   try {
     console.log('About to call createPass');
-    const { ndc, labelName, pharmacyName, price } = req.query;
 
     const pkpass = await createPass({
-      serial: (ndc as string) || '90MA019309343023',
-      number: (ndc as string) || '90MA019309343023',
+      serial: '90MA019309343023',
+      number: '90MA019309343023',
       bin: '015926',
       pcn: 'PRXIDST',
       group: 'IDST01',

--- a/backend/src/routes/applewallet.route.ts
+++ b/backend/src/routes/applewallet.route.ts
@@ -8,11 +8,15 @@ router.get('/', async (req, res, next) => {
   console.log('Route hit');
   try {
     console.log('About to call createPass');
-    const cardNumber = '90MA019309343023';
+    const { ndc, labelName, pharmacyName, price } = req.query;
 
     const pkpass = await createPass({
-      serial: cardNumber,
-      number: cardNumber,
+      serial: (ndc as string) || '90MA019309343023',
+      number: (ndc as string) || '90MA019309343023',
+      bin: '015926',
+      pcn: 'PRXIDST',
+      group: 'IDST01',
+      memberId: 'IDST733224411',
     });
 
     res.setHeader('Content-Type', 'application/vnd.apple.pkpass');

--- a/backend/src/services/applewallet.service.ts
+++ b/backend/src/services/applewallet.service.ts
@@ -1,15 +1,18 @@
 console.log('applewallet.service.ts loaded');
 import { PKPass } from 'passkit-generator';
 import path from 'path';
-import fs from 'fs';
 import { getAppleWalletSecret, getAppleWalletWWDRSecret } from '../secrets/secrets';
 
 type PassInput = {
   serial: string;
   number: string;
+  bin: string;
+  pcn: string;
+  group: string;
+  memberId: string;
 };
 
-export async function createPass({ serial, number }: PassInput) {
+export async function createPass({ serial, number, bin, pcn, group, memberId }: PassInput) {
   /*Gets the secret from AWS*/
   console.log('Reached the Create Pass function');
   const secret = await getAppleWalletSecret();
@@ -45,11 +48,14 @@ export async function createPass({ serial, number }: PassInput) {
     });
   }
 
-  const modelDir = path.join(__dirname, '../wallet-pass.pass');
-  pass.addBuffer('icon.png', fs.readFileSync(path.join(modelDir, 'icon.png')));
-  pass.addBuffer('icon@2x.png', fs.readFileSync(path.join(modelDir, 'icon@2x.png')));
-  pass.addBuffer('logo.png', fs.readFileSync(path.join(modelDir, 'logo.png')));
-  pass.addBuffer('logo@2x.png', fs.readFileSync(path.join(modelDir, 'logo@2x.png')));
+  pass.secondaryFields.push(
+    { key: 'bin', label: 'BIN', value: bin },
+    { key: 'pcn', label: 'PCN', value: pcn }
+  );
+  pass.auxiliaryFields.push(
+    { key: 'group', label: 'GROUP', value: group },
+    { key: 'memberId', label: 'MEMBER ID', value: memberId }
+  );
 
   pass.setBarcodes({
     message: number,

--- a/backend/src/wallet-pass.pass/pass.json
+++ b/backend/src/wallet-pass.pass/pass.json
@@ -11,7 +11,9 @@
         "label": "Card #",
         "value": "90MA019309343023"
       }
-    ]
+    ],
+    "secondaryFields": [],
+    "auxiliaryFields": []
   },
   "barcode": {
     "format": "PKBarcodeFormatCode128",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Apple Wallet passes now include additional identity fields (e.g., BIN/PCN/group/member) for richer display.

* **Enhancements**
  * Pass payload structure updated to explicitly include secondary and auxiliary field collections.
  * Pass generation simplified with streamlined asset handling.

* **Tests**
  * Unit tests updated to cover the expanded pass input shape.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->